### PR TITLE
Added the ability to properly format string values

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -114,4 +114,100 @@ describe('K.case', () => {
 
     expect(result).toBe(expected);
   });
+  describe('value formatting', () => {
+    describe('when value', () => {
+      it('should be able to handle empty string as a value', () => {
+        const expected = `(CASE WHEN column='' THEN 1 ELSE 0 END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', '')
+          .thenElse(1, 0)
+          .toQuery();
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should be able to handle string as a value', () => {
+        const expected = `(CASE WHEN column='hello' THEN 1 ELSE 0 END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', 'hello')
+          .thenElse(1, 0)
+          .toQuery();
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should be able to handle numbers of a value', () => {
+        const expected = `(CASE WHEN column=1 THEN 1 ELSE 0 END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', 1)
+          .thenElse(1, 0)
+          .toQuery();
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('thenElse values', () => {
+      it('should be able to handle string as a value', () => {
+        const expected = `(CASE WHEN column='hello' THEN '1' ELSE '0' END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', 'hello')
+          .thenElse('1', '0')
+          .toQuery();
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should be able to handle numbers of a value', () => {
+        const expected = `(CASE WHEN column=1 THEN 1 ELSE 0 END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', 1)
+          .thenElse(1, 0)
+          .toQuery();
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('else values', () => {
+      it('should be able to handle string as a value', () => {
+        const expected = `(CASE WHEN column=1 OR column_two=3 THEN (CASE WHEN column=2 THEN 2 ELSE 5 END) ELSE 'wow' END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', 1)
+          .orWhen('column_two', '=', 3)
+          .thenElse(
+            K.queryBuilder()
+              .when('column', '=', 2)
+              .thenElse(2, 5)
+          )
+          .else('wow')
+          .toQuery();
+
+        expect(result).toBe(expected);
+      });
+
+      it('should be able to handle numbers of a value', () => {
+        const expected = `(CASE WHEN column=1 OR column_two=3 THEN (CASE WHEN column=2 THEN 2 ELSE 5 END) ELSE 0 END)`;
+
+        const result = K.queryBuilder()
+          .when('column', '=', 1)
+          .orWhen('column_two', '=', 3)
+          .thenElse(
+            K.queryBuilder()
+              .when('column', '=', 2)
+              .thenElse(2, 5)
+          )
+          .else(0)
+          .toQuery();
+
+        expect(result).toBe(expected);
+      });
+    });
+  });
 });

--- a/src/__tests__/kase.spec.js
+++ b/src/__tests__/kase.spec.js
@@ -52,4 +52,94 @@ describe('.kase', () => {
 
     expect(result).toBe(expected);
   });
+
+  describe('value formatting', () => {
+    describe('when value', () => {
+      it('should be able to handle empty string as a value', () => {
+        const expected = `(CASE WHEN column='' THEN 1 ELSE 0 END)`;
+
+        const result = kase()
+          .when('column', '=', '')
+          .thenElse(1, 0);
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should be able to handle string as a value', () => {
+        const expected = `(CASE WHEN column='hello' THEN 1 ELSE 0 END)`;
+
+        const result = kase()
+          .when('column', '=', 'hello')
+          .thenElse(1, 0);
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should be able to handle numbers of a value', () => {
+        const expected = `(CASE WHEN column=1 THEN 1 ELSE 0 END)`;
+
+        const result = kase()
+          .when('column', '=', 1)
+          .thenElse(1, 0);
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('thenElse values', () => {
+      it('should be able to handle string as a value', () => {
+        const expected = `(CASE WHEN column='hello' THEN '1' ELSE '0' END)`;
+
+        const result = kase()
+          .when('column', '=', 'hello')
+          .thenElse('1', '0');
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should be able to handle numbers of a value', () => {
+        const expected = `(CASE WHEN column=1 THEN 1 ELSE 0 END)`;
+
+        const result = kase()
+          .when('column', '=', 1)
+          .thenElse(1, 0);
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('else values', () => {
+      it('should be able to handle string as a value', () => {
+        const expected = `(CASE WHEN column=1 OR column_two=3 THEN (CASE WHEN column=2 THEN 2 ELSE 5 END) ELSE 'wow' END)`;
+
+        const result = kase()
+          .when('column', '=', 1)
+          .orWhen('column_two', '=', 3)
+          .thenElse(
+            kase()
+              .when('column', '=', 2)
+              .thenElse(2, 5)
+          )
+          .else('wow');
+
+        expect(result).toBe(expected);
+      });
+
+      it('should be able to handle numbers of a value', () => {
+        const expected = `(CASE WHEN column=1 OR column_two=3 THEN (CASE WHEN column=2 THEN 2 ELSE 5 END) ELSE 0 END)`;
+
+        const result = kase()
+          .when('column', '=', 1)
+          .orWhen('column_two', '=', 3)
+          .thenElse(
+            kase()
+              .when('column', '=', 2)
+              .thenElse(2, 5)
+          )
+          .else(0);
+
+        expect(result).toBe(expected);
+      });
+    });
+  });
 });

--- a/src/kase.js
+++ b/src/kase.js
@@ -1,8 +1,19 @@
 function when(op) {
   return function(column, operator, value) {
-    return `${(op && `${op}`) || 'WHEN'} ${column}${operator}${value}`;
+    return `${(op && `${op}`) || 'WHEN'} ${column}${operator}${formatValue(
+      value
+    )}`;
   };
 }
+
+const formatValue = v => {
+  if (typeof v === 'string') {
+    if (v.includes('CASE')) return v;
+
+    return `'${v}'`;
+  }
+  return v;
+};
 
 const or = when('OR');
 const and = when('AND');
@@ -30,8 +41,8 @@ function kase() {
     thenElse(t, e) {
       const hasE = e !== undefined;
 
-      k.q.push(`THEN ${t}`);
-      hasE && k.q.push(`ELSE ${e} END`);
+      k.q.push(`THEN ${formatValue(t)}`);
+      hasE && k.q.push(`ELSE ${formatValue(e)} END`);
 
       if (!hasE) return k;
 
@@ -41,7 +52,7 @@ function kase() {
       return str;
     },
     else(e) {
-      k.q.push(`ELSE ${e} END`);
+      k.q.push(`ELSE ${formatValue(e)} END`);
 
       const str = `(${k.q.join(' ')})`;
       k.q = [];


### PR DESCRIPTION
* **Added the ability to properly format strings for `when`, `then` and `thenElse` to avoid the usage of
 ```javascript
when('one','=',"'str'")
```
to output 
```WHEN one='str'```
